### PR TITLE
add zap out

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -223,7 +223,9 @@
   "youWillReceive": "You will receive at least",
   "youWillRemove": "You will remove",
   "zap": "Zap in",
+  "zapOut": "Zap out",
   "zapInAmount": "Zap in amount",
+  "zapOutAmount": "Zap out amount",
   "fees": "Fees",
   "feesInfo": "Some explanation about where the fees come from"
 }

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -201,7 +201,12 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
 
   const handleUserInput = (amount: string) => {
     setZapInAmount(amount)
-    onUserInput(Field.INPUT, amount)
+
+    if (zapType === 'zapIn') {
+      onUserInput(Field.INPUT, amount)
+    } else if (zapType === 'zapOut') {
+      onUserInput(Field.OUTPUT, amount)
+    }
   }
 
   const displayedPercentageReturn =

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -297,10 +297,10 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
       )}
 
       <ManageMenu $expanded={showManageMenu}>
-        <ButtonPrimary onClick={() => handleSetZapType('zapIn')} padding="8px">
+        <ButtonPrimary onClick={() => handleSetZapType('zapIn')} padding="8px" disabled={zapType === 'zapIn'}>
           {t('zap')}
         </ButtonPrimary>
-        <ButtonPrimary onClick={() => handleSetZapType('zapOut')} padding="8px">
+        <ButtonPrimary onClick={() => handleSetZapType('zapOut')} padding="8px" disabled={zapType === 'zapOut'}>
           {t('zapOut')}
         </ButtonPrimary>
       </ManageMenu>

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -12,7 +12,7 @@ import React, { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { Field } from 'state/swap/actions'
-import { useSwapActionHandlers } from 'state/swap/hooks'
+import { useDerivedSwapInfo, useSwapActionHandlers } from 'state/swap/hooks'
 import { updateUserAprMode } from 'state/user/actions'
 import { useIsAprMode } from 'state/user/hooks'
 import styled, { ThemeContext } from 'styled-components'
@@ -113,6 +113,7 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
   const userAprMode = useIsAprMode()
   const { address } = useContractKit()
   const dispatch = useDispatch()
+  const { inputError: swapInputError } = useDerivedSwapInfo()
 
   const token0 = useToken(compoundBotSummary.token0Address) || undefined
   const token1 = useToken(compoundBotSummary.token1Address) || undefined
@@ -336,7 +337,7 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
               )}
             </ButtonConfirmed>
           )}
-          <ButtonLight onClick={onZap} padding="8px">
+          <ButtonLight onClick={onZap} padding="8px" disabled={!!swapInputError}>
             {t('approve')}
           </ButtonLight>
         </RowBetween>

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -131,7 +131,11 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
   const [zapAmount, setZapInAmount] = useState('')
   const [zapCurrency, setZapInCurrency] = useState<Token | undefined>()
 
-  const { approval, approveCallback, onZap, showApproveFlow, currencies, approvalSubmitted } = useZapFunctions()
+  const onZapSubmitted = (): void => {
+    setZapType(null)
+  }
+  const { approval, approveCallback, onZap, showApproveFlow, currencies, approvalSubmitted } =
+    useZapFunctions(onZapSubmitted)
 
   const isStaking = compoundBotSummary.amountUserLP > 0
 
@@ -311,17 +315,6 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
           otherCurrency={null}
           id="zap-currency-input"
         />
-        <RowBetween>
-          <RowFixed>
-            <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
-              {t('fees')}
-            </TYPE.black>
-            <QuestionHelper text={t('feesInfo')} />
-          </RowFixed>
-          <TYPE.black fontSize={14} color={theme.text1}>
-            {'TODO: calculate fee'}
-          </TYPE.black>
-        </RowBetween>
 
         <RowBetween gap="12px">
           {showApproveFlow && (

--- a/src/components/earn/useZapFunctions.ts
+++ b/src/components/earn/useZapFunctions.ts
@@ -49,7 +49,7 @@ export const useZapFunctions = () => {
       (approvalSubmitted && approval === ApprovalState.APPROVED)) &&
     !(priceImpactSeverity > 3 && !isExpertMode)
 
-  const handleZapIn = useCallback(() => {
+  const onZap = useCallback(() => {
     if (priceImpactWithoutFee && !confirmPriceImpactWithoutFee(priceImpactWithoutFee)) {
       return
     }
@@ -75,7 +75,7 @@ export const useZapFunctions = () => {
   return {
     showApproveFlow,
     approval,
-    onZapIn: handleZapIn,
+    onZap,
     approveCallback,
     approvalSubmitted,
     currencies,

--- a/src/components/earn/useZapFunctions.ts
+++ b/src/components/earn/useZapFunctions.ts
@@ -10,7 +10,7 @@ import { computeTradePriceBreakdown, warningSeverity } from 'utils/prices'
 // most of this logic taken from the Swap page
 // TODO: make use of expert mode/ displaying swap message/having a confirmation
 // modal for swap
-export const useZapFunctions = () => {
+export const useZapFunctions = (onZapSubmitted) => {
   const [{ showConfirm, tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{
     showConfirm: boolean
     tradeToConfirm: Trade | undefined
@@ -59,9 +59,15 @@ export const useZapFunctions = () => {
     setSwapState({ attemptingTxn: true, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: undefined })
     swapCallback()
       .then((hash) => {
+        if (onZapSubmitted) {
+          onZapSubmitted()
+        }
         setSwapState({ attemptingTxn: false, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: hash })
       })
       .catch((error) => {
+        if (onZapSubmitted) {
+          onZapSubmitted()
+        }
         setSwapState({
           attemptingTxn: false,
           tradeToConfirm,

--- a/src/pages/Compound/useCompoundRegistry.ts
+++ b/src/pages/Compound/useCompoundRegistry.ts
@@ -42,7 +42,7 @@ export const useCompoundRegistry = () => {
       const totalLP = await farmBot.methods.getLpAmount(totalFP).call()
       const exchangeRate = totalLP / totalFP
 
-      let amountUserFP = await farmBot.methods.balanceOf(address).call()
+      let amountUserFP = address ? await farmBot.methods.balanceOf(address).call() : 0
       amountUserFP = amountUserFP > 10 ? amountUserFP : 0
       const amountUserLP = await farmBot.methods.getLpAmount(amountUserFP).call()
 

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -24,14 +24,14 @@ export function useSwapState(): AppState['swap'] {
 }
 
 export function useSwapActionHandlers(): {
-  onCurrencySelection: (field: Field, currency: Token) => void
+  onCurrencySelection: (field: Field, currency: Token | null) => void
   onSwitchTokens: () => void
   onUserInput: (field: Field, typedValue: string) => void
   onChangeRecipient: (recipient: string | null) => void
 } {
   const dispatch = useDispatch<AppDispatch>()
   const onCurrencySelection = useCallback(
-    (field: Field, currency: Token) => {
+    (field: Field, currency: Token | null) => {
       dispatch(
         selectCurrency({
           field,


### PR DESCRIPTION
TODO:
- show error states (use the "swapInputError" variable to display an error and disable the buttons)
- we should refresh the card once a user has zapped in/zapped out - i couldn't get this data to refresh, as we need to trigger a refresh of `useCompoundRegistry`. i think the easiest way to do this is to make `useCompoundRegistry` listen to a redux variable and re-call the contract after a user action