### PR TITLE
Add slider for zap-outs, prevent swaps when price impact is too high

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -228,6 +228,8 @@
   "zapOut": "Zap out",
   "zapInAmount": "Zap in amount",
   "zapOutAmount": "Zap out amount",
+  "zapOutPriceImpactHelper": "Minimum amount you will receive. If there is a large, unfavorable price movement before confirmation, your transaction will revert.",
+  "zapOutSelect": "Select a token to zap out to:",
   "fees": "Fees",
   "feesInfo": "Some explanation about where the fees come from",
   "ZapInEdu": "What is Zap in?",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -128,6 +128,7 @@
   "poolTokens": "Pool Tokens",
   "PoolTokensInRewardsPool": "Pool tokens in rewards pool",
   "priceChange": "Expected price slippage",
+  "priceImpact": "Price impact too high",
   "rate": "rate",
   "Rate": "Rate",
   "RecentTransactions": "Recent transactions",

--- a/src/components/compound/ConfirmAddCompoundModalBottom.tsx
+++ b/src/components/compound/ConfirmAddCompoundModalBottom.tsx
@@ -1,11 +1,10 @@
-import { Fraction, Percent, Token, TokenAmount } from '@ubeswap/sdk'
+import { Token, TokenAmount } from '@ubeswap/sdk'
 import React from 'react'
 import { Text } from 'rebass'
 
 import { ButtonPrimary } from '../../components/Button'
 import CurrencyLogo from '../../components/CurrencyLogo'
 import { RowBetween, RowFixed } from '../../components/Row'
-import { Field } from '../../state/mint/actions'
 import { TYPE } from '../../theme'
 
 export function ConfirmAddCompoundModalBottom({

--- a/src/components/compound/ConfirmWithdrawCompoundModalBottom.tsx
+++ b/src/components/compound/ConfirmWithdrawCompoundModalBottom.tsx
@@ -1,11 +1,10 @@
-import { Fraction, Percent, Token, TokenAmount } from '@ubeswap/sdk'
+import { Token, TokenAmount } from '@ubeswap/sdk'
 import React from 'react'
 import { Text } from 'rebass'
 
 import { ButtonPrimary } from '../../components/Button'
 import CurrencyLogo from '../../components/CurrencyLogo'
 import { RowBetween, RowFixed } from '../../components/Row'
-import { Field } from '../../state/mint/actions'
 import { TYPE } from '../../theme'
 
 export function ConfirmWithdrawCompoundModalBottom({

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -22,6 +22,7 @@ import styled, { ThemeContext } from 'styled-components'
 import { useCalcAPY } from 'utils/calcAPY'
 import { computeTradePriceBreakdown } from 'utils/prices'
 import { useCUSDPrices } from 'utils/useCUSDPrice'
+import { toBN } from 'web3-utils'
 
 import { BLOCKED_PRICE_IMPACT_NON_EXPERT, ONE_BIPS } from '../../constants/'
 import { borderRadius, TYPE } from '../../theme'

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -130,11 +130,7 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
 
   const { v2Trade: trade, inputError: swapInputError } = useDerivedSwapInfo()
   const { priceImpactWithoutFee } = trade ? computeTradePriceBreakdown(trade) : {}
-  const isPriceImpactTooHigh = priceImpactWithoutFee
-    ? priceImpactWithoutFee.lessThan(BLOCKED_PRICE_IMPACT_NON_EXPERT)
-      ? false
-      : true
-    : false
+  const isPriceImpactTooHigh = !!priceImpactWithoutFee?.greaterThan(BLOCKED_PRICE_IMPACT_NON_EXPERT)
 
   const token0 = useToken(compoundBotSummary.token0Address) || undefined
   const token1 = useToken(compoundBotSummary.token1Address) || undefined

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useContractKit } from '@celo-tools/use-contractkit'
-import { Token } from '@ubeswap/sdk'
+import { Fraction, Token } from '@ubeswap/sdk'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
 import Loader from 'components/Loader'
 import QuestionHelper from 'components/QuestionHelper'
@@ -9,22 +9,31 @@ import { useToken } from 'hooks/Tokens'
 import { ApprovalState } from 'hooks/useApproveCallback'
 import { CompoundBotSummary } from 'pages/Compound/useCompoundRegistry'
 import { useLPValue } from 'pages/Earn/useLPValue'
-import React, { useContext, useState } from 'react'
+import { MaxButton } from 'pages/Pool/styleds'
+import React, { useCallback, useContext, useState } from 'react'
+import { ArrowDown } from 'react-feather'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
+import { Text } from 'rebass'
 import { Field } from 'state/swap/actions'
 import { useDerivedSwapInfo, useSwapActionHandlers } from 'state/swap/hooks'
 import { useIsAprMode, useUserSlippageTolerance } from 'state/user/hooks'
 import styled, { ThemeContext } from 'styled-components'
 import { useCalcAPY } from 'utils/calcAPY'
+import { computeTradePriceBreakdown } from 'utils/prices'
 import { useCUSDPrices } from 'utils/useCUSDPrice'
 import { fromWei, toBN } from 'web3-utils'
 
+import { BLOCKED_PRICE_IMPACT_NON_EXPERT, ONE_BIPS } from '../../constants/'
 import { borderRadius, TYPE } from '../../theme'
-import { ButtonConfirmed, ButtonLight, ButtonPrimary } from '../Button'
-import { AutoColumn } from '../Column'
+import useDebouncedChangeHandler from '../../utils/useDebouncedChangeHandler'
+import { ButtonConfirmed, ButtonError, ButtonLight, ButtonPrimary } from '../Button'
+import { LightCard } from '../Card'
+import { AutoColumn, ColumnCenter } from '../Column'
+import CurrencyLogo from '../CurrencyLogo'
 import DoubleCurrencyLogo from '../DoubleLogo'
-import { AutoRow, RowBetween, RowFixed } from '../Row'
+import Row, { AutoRow, RowBetween, RowFixed } from '../Row'
+import Slider from '../Slider'
 import { useZapFunctions } from './useZapFunctions'
 import { ZapDetails } from './ZapDetails'
 
@@ -90,6 +99,11 @@ const ZapDetailsContainer = styled.div<{ $expanded: boolean }>`
   overflow: hidden;
 `
 
+const ZapOutTokenSelectorContainer = styled.div`
+  #zap-out-token-selector {
+  }
+`
+
 interface Props {
   compoundBotSummary: CompoundBotSummary
 }
@@ -113,7 +127,14 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
   const userAprMode = useIsAprMode()
   const { address } = useContractKit()
   const dispatch = useDispatch()
+
   const { v2Trade: trade, inputError: swapInputError } = useDerivedSwapInfo()
+  const { priceImpactWithoutFee } = trade ? computeTradePriceBreakdown(trade) : {}
+  const isPriceImpactTooHigh = priceImpactWithoutFee
+    ? priceImpactWithoutFee.lessThan(BLOCKED_PRICE_IMPACT_NON_EXPERT)
+      ? false
+      : true
+    : false
 
   const token0 = useToken(compoundBotSummary.token0Address) || undefined
   const token1 = useToken(compoundBotSummary.token1Address) || undefined
@@ -177,6 +198,9 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
 
   const handleSetZapType = (type: ZapType) => {
     setZapType(type)
+    if (type == 'zapOut') {
+      setZapOutPercentage('50')
+    }
     onCurrencySelection(Field.INPUT, null)
     onCurrencySelection(Field.OUTPUT, null)
     onUserInput(Field.INPUT, '')
@@ -186,13 +210,20 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
 
   const handleUserInput = (amount: string) => {
     setZapInAmount(amount)
-
-    if (zapType === 'zapIn') {
-      onUserInput(Field.INPUT, amount)
-    } else if (zapType === 'zapOut') {
-      onUserInput(Field.OUTPUT, amount)
-    }
+    onUserInput(Field.INPUT, amount)
   }
+
+  const zapOutPercentChangeCallback = useCallback(
+    (value: number) => {
+      const rawAmountZapOut = toBN(compoundBotSummary.amountUserFP).mul(toBN(value)).div(toBN(100)).toString()
+      const adjustedAmountZapOut = new Fraction(toBN(rawAmountZapOut), toBN(10).pow(toBN(18))).toSignificant(100)
+      setZapInAmount(rawAmountZapOut)
+      onUserInput(Field.INPUT, adjustedAmountZapOut)
+    },
+    [handleUserInput]
+  )
+
+  const [zapOutPercentage, setZapOutPercentage] = useDebouncedChangeHandler('50', zapOutPercentChangeCallback)
 
   if (!token0 || !token1) {
     return (
@@ -275,16 +306,93 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
       </ManageMenu>
 
       <PoolDetailsContainer $expanded={!!zapType}>
-        <CurrencyInputPanel
-          value={zapAmount}
-          onUserInput={handleUserInput}
-          label={zapType === 'zapIn' ? t('zapInAmount') : t('zapOutAmount')}
-          showMaxButton={false}
-          currency={zapCurrency}
-          onCurrencySelect={handleCurrencySelect}
-          otherCurrency={null}
-          id="zap-currency-input"
-        />
+        {zapType == 'zapIn' && (
+          <CurrencyInputPanel
+            value={zapAmount}
+            onUserInput={handleUserInput}
+            label={zapType === 'zapIn' ? t('zapInAmount') : t('zapOutAmount')}
+            showMaxButton={false}
+            currency={zapCurrency}
+            onCurrencySelect={handleCurrencySelect}
+            otherCurrency={null}
+            id="zap-currency-input"
+          />
+        )}
+
+        {zapType == 'zapOut' && (
+          <AutoColumn>
+            <RowBetween padding="12px">
+              <TYPE.black fontWeight={500}>
+                <span>Select a token to zap out to:</span>
+              </TYPE.black>
+
+              <ZapOutTokenSelectorContainer>
+                <CurrencyInputPanel
+                  value={zapAmount}
+                  onUserInput={handleUserInput}
+                  label={zapType === 'zapIn' ? t('zapInAmount') : t('zapOutAmount')}
+                  showMaxButton={false}
+                  currency={zapCurrency}
+                  onCurrencySelect={handleCurrencySelect}
+                  otherCurrency={null}
+                  hideInput={true}
+                  id="zap-out-token-selector"
+                />
+              </ZapOutTokenSelectorContainer>
+            </RowBetween>
+            {zapCurrency && (
+              <AutoColumn>
+                <LightCard>
+                  <>
+                    <Row style={{ alignItems: 'flex-end' }}>
+                      <Text fontSize={72} fontWeight={500}>
+                        {zapOutPercentage}%
+                      </Text>
+                    </Row>
+                    <Slider value={zapOutPercentage} onChange={setZapOutPercentage} />
+                    <RowBetween>
+                      <MaxButton onClick={() => setZapOutPercentage('25')} width="20%">
+                        25%
+                      </MaxButton>
+                      <MaxButton onClick={() => setZapOutPercentage('50')} width="20%">
+                        50%
+                      </MaxButton>
+                      <MaxButton onClick={() => setZapOutPercentage('75')} width="20%">
+                        75%
+                      </MaxButton>
+                      <MaxButton onClick={() => setZapOutPercentage('100')} width="20%">
+                        Max
+                      </MaxButton>
+                    </RowBetween>
+                  </>
+                </LightCard>
+                {!!trade && (
+                  <>
+                    <ColumnCenter>
+                      <ArrowDown size="16" color={theme.text2} />
+                    </ColumnCenter>
+                    <LightCard>
+                      <RowBetween>
+                        <RowFixed>
+                          <Text fontSize={24} fontWeight={500}>
+                            {trade.minimumAmountOut(ONE_BIPS.multiply(toBN(allowedSlippage))).toFixed(2) || '-'}
+                          </Text>
+                          <QuestionHelper text="Minimum amount you will receive. If there is a large, unfavorable price movement before confirmation, your transaction will revert." />
+                        </RowFixed>
+                        <RowFixed>
+                          <CurrencyLogo currency={zapCurrency} style={{ marginRight: '12px' }} />
+                          <Text fontSize={24} fontWeight={500}>
+                            {zapCurrency?.symbol}
+                          </Text>
+                        </RowFixed>
+                      </RowBetween>
+                    </LightCard>
+                  </>
+                )}
+              </AutoColumn>
+            )}
+          </AutoColumn>
+        )}
 
         <RowBetween gap="12px">
           {showApproveFlow && (
@@ -306,9 +414,15 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
               )}
             </ButtonConfirmed>
           )}
-          <ButtonLight onClick={onZap} padding="8px" disabled={!!swapInputError}>
-            {zapType === 'zapIn' ? t('zap') : t('zapOut')}
-          </ButtonLight>
+          {isPriceImpactTooHigh ? (
+            <ButtonError padding="8px" disabled={true} error={true}>
+              {t('priceImpact')}
+            </ButtonError>
+          ) : (
+            <ButtonLight onClick={onZap} padding="8px" disabled={!!swapInputError}>
+              {zapType === 'zapIn' ? t('zapIn') : t('zapOut')}
+            </ButtonLight>
+          )}
         </RowBetween>
       </PoolDetailsContainer>
 

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -323,7 +323,7 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
           <AutoColumn>
             <RowBetween padding="12px">
               <TYPE.black fontWeight={500}>
-                <span>Select a token to zap out to:</span>
+                <span>{t('zapOutSelect')}</span>
               </TYPE.black>
 
               <ZapOutTokenSelectorContainer>
@@ -377,7 +377,7 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
                           <Text fontSize={24} fontWeight={500}>
                             {trade.minimumAmountOut(ONE_BIPS.multiply(toBN(allowedSlippage))).toFixed(2) || '-'}
                           </Text>
-                          <QuestionHelper text="Minimum amount you will receive. If there is a large, unfavorable price movement before confirmation, your transaction will revert." />
+                          <QuestionHelper text={t('zapOutPriceImpactHelper')} />
                         </RowFixed>
                         <RowFixed>
                           <CurrencyLogo currency={zapCurrency} style={{ marginRight: '12px' }} />

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -89,7 +89,7 @@ export default function App() {
       <Route component={DarkModeQueryParamReader} />
       <AppWrapper>
         <ConstructionBanner>
-          Warning: Revo's smart contracts are pending full audits. Please use with caution!
+          Warning: Revo&apos;s smart contracts are pending full audits. Please use with caution!
         </ConstructionBanner>
         <HeaderWrapper>
           <Header />

--- a/src/pages/Pool/styleds.tsx
+++ b/src/pages/Pool/styleds.tsx
@@ -14,9 +14,9 @@ export const ClickableText = styled(Text)`
 `
 export const MaxButton = styled.button<{ width: string }>`
   padding: 0.5rem 1rem;
-  background-color: ${({ theme }) => theme.primary5};
-  border: 1px solid ${({ theme }) => theme.primary5};
-  border-radius: 0.5rem;
+  background-color: ${({ theme }) => theme.primary3};
+  border: 1px solid ${({ theme }) => theme.primary3};
+  border-radius: 8px;
   font-size: 1rem;
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 0.25rem 0.5rem;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,7 +9,6 @@ import { IUniswapV2Router02, UbeswapMoolaRouter } from 'generated/index'
 import { ROUTER_ADDRESS, UBESWAP_MOOLA_ROUTER_ADDRESS } from '../constants'
 import IUniswapV2Router02ABI from '../constants/abis/IUniswapV2Router02.json'
 import UbeswapMoolaRouterABI from '../constants/abis/UbeswapMoolaRouter.json'
-
 import { TokenAddressMap } from '../state/lists/hooks'
 
 // returns the checksummed address if the address is valid, otherwise returns false


### PR DESCRIPTION
This PR adds a slider interface for zap-outs. I figured it would be good to prevent zap-outs when price impact becomes too high, since currently it's possible to zap in/out with very high price impact by accident. Incidentally, these changes also prevent zap-ins when price impact is too high as well.

![2022-02-28-191315_1025x1211_scrot](https://user-images.githubusercontent.com/569401/156080680-a34b8a26-26db-47d5-a810-8bfb7936da1c.png)

![2022-02-28-191358_1035x784_scrot](https://user-images.githubusercontent.com/569401/156080744-1651ba35-f5b8-4103-ac96-425937e35b3e.png)

