### PR TITLE
Various UI improvements

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -232,8 +232,8 @@
   "zapOutSelect": "Select a token to zap out to:",
   "fees": "Fees",
   "feesInfo": "Some explanation about where the fees come from",
-  "ZapInEdu": "What is Zap in?",
-  "ZapInEduDesc": "\"Zap In\" allows you to swap any token (like cUSD or CELO) for a share in a yield farm with automatic compound interest. Learn more about DeFi on Revo ",
+  "zapInEdu": "What is Zap in?",
+  "zapInEduDesc": "\"Zap In\" allows you to swap any token (like cUSD or CELO) for a share in a yield farm with automatic compound interest. Learn more about DeFi on Revo ",
   "here": "here",
   "APYInfo": "APY is calculated assuming auto-compounding once per hour"
 }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -12,6 +12,7 @@ const Base = styled(RebassButton)<{
   width?: string
   borderRadius?: string
   altDisabledStyle?: boolean
+  inverse?: boolean
 }>`
   transition: 0.25s ease;
   padding: ${({ padding }) => (padding ? padding : '18px')};
@@ -19,7 +20,6 @@ const Base = styled(RebassButton)<{
   font-weight: 500;
   text-align: center;
   border-radius: ${borderRadius}px;
-  border-radius: ${({ borderRadius }) => borderRadius && borderRadius};
   outline: none;
   border: 1px solid transparent;
   color: white;
@@ -41,19 +41,18 @@ const Base = styled(RebassButton)<{
 `
 
 export const ButtonPrimary = styled(Base)`
-  background-color: ${({ theme }) => theme.primary1};
+  background-color: ${({ theme, inverse }) => (inverse ? theme.white : theme.primary1)};
+  border-color: ${({ theme }) => theme.primary1};
   font-weight: bold;
-  color: white;
+  color: ${({ theme, inverse }) => (inverse ? theme.primary1 : theme.white)};
   &:focus {
-    box-shadow: 0 0 0 1pt ${({ theme }) => darken(0.05, theme.primary1)};
-    background-color: ${({ theme }) => darken(0.05, theme.primary1)};
+    background-color: ${({ theme, inverse }) => (inverse ? theme.white : darken(0.05, theme.primary1))};
   }
   &:hover {
-    background-color: ${({ theme }) => darken(0.05, theme.primary1)};
+    background-color: ${({ theme, inverse }) => (inverse ? theme.white : darken(0.05, theme.primary1))};
   }
   &:active {
-    box-shadow: 0 0 0 1pt ${({ theme }) => darken(0.1, theme.primary1)};
-    background-color: ${({ theme }) => darken(0.1, theme.primary1)};
+    background-color: ${({ theme, inverse }) => (inverse ? theme.white : darken(0.1, theme.primary1))};
   }
   &:disabled {
     background-color: ${({ theme, altDisabledStyle, disabled }) =>
@@ -62,10 +61,8 @@ export const ButtonPrimary = styled(Base)`
       altDisabledStyle ? (disabled ? theme.text3 : 'white') : theme.text3};
     cursor: auto;
     box-shadow: none;
-    border: 1px solid transparent;
     outline: none;
     opacity: ${({ altDisabledStyle }) => (altDisabledStyle ? '0.5' : '1')};
-    border-radius: ${borderRadius}px;
   }
 `
 
@@ -118,19 +115,22 @@ export const ButtonSecondary = styled(Base)`
   color: ${({ theme }) => theme.primary1};
   background-color: transparent;
   font-size: 16px;
-  border-radius: ${borderRadius}px;
+  box-sizing: content-box;
   padding: ${({ padding }) => (padding ? padding : '10px')};
 
   &:focus {
-    box-shadow: 0 0 0 1pt ${({ theme }) => theme.primary4};
+    box-shadow: 0 0 0 1pt ${({ theme }) => theme.primary3};
     border: 1px solid ${({ theme }) => theme.primary3};
+    color: ${({ theme }) => theme.primary3};
   }
   &:hover {
     border: 1px solid ${({ theme }) => theme.primary3};
+    color: ${({ theme }) => theme.primary3};
   }
   &:active {
-    box-shadow: 0 0 0 1pt ${({ theme }) => theme.primary4};
+    box-shadow: 0 0 0 1pt ${({ theme }) => theme.primary3};
     border: 1px solid ${({ theme }) => theme.primary3};
+    color: ${({ theme }) => theme.primary3};
   }
   &:disabled {
     opacity: 50%;

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -68,7 +68,7 @@ const Container = styled.div<{ hideInput: boolean }>`
 `
 
 const StyledTokenName = styled.span<{ active?: boolean }>`
-  ${({ active }) => (active ? '  margin: 0 0.25rem 0 0.75rem;' : '  margin: 0 0.25rem 0 0.25rem;')}
+  ${({ active }) => (active ? '  margin: 0 0.25rem 0 0.75rem;' : '  margin: 0 0.25rem 0 0.25rem; border: none;')}
   font-size:  ${({ active }) => (active ? '20px' : '16px')};
 `
 

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -61,17 +61,20 @@ const MenuFlyout = styled.span`
   flex-direction: column;
   font-size: 1rem;
   position: absolute;
-  top: 4rem;
+  top: 3rem;
   right: 0rem;
   z-index: 100;
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
-    top: -17.25rem;
+    top: unset;
+    bottom: 3rem;
   `};
 `
 
 const MenuItem = styled(ExternalLink)`
   flex: 1;
+  display: flex;
+  align-items: center;
   padding: 0.5rem 0.5rem;
   color: ${({ theme }) => theme.text2};
   :hover {

--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -195,7 +195,7 @@ export function CurrencySearch({
   return (
     <ContentWrapper>
       <PaddedColumn gap="16px">
-        <RowBetween>
+        <RowBetween border="none">
           <Text fontWeight={500} fontSize={16}>
             {t('selectToken')}
           </Text>

--- a/src/components/SearchModal/Manage.tsx
+++ b/src/components/SearchModal/Manage.tsx
@@ -6,7 +6,7 @@ import { ArrowLeft } from 'react-feather'
 import { useTranslation } from 'react-i18next'
 import { Text } from 'rebass'
 import styled from 'styled-components'
-import { CloseIcon } from 'theme'
+import { borderRadius, CloseIcon } from 'theme'
 
 import { CurrencyModalView } from './CurrencySearchModal'
 import { ManageLists } from './ManageLists'
@@ -21,7 +21,7 @@ const Wrapper = styled.div`
 
 const ToggleWrapper = styled(RowBetween)`
   background-color: ${({ theme }) => theme.bg3};
-  border-radius: 12px;
+  border-radius: ${borderRadius}px;
   padding: 6px;
 `
 
@@ -31,7 +31,7 @@ const ToggleOption = styled.div<{ active?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 12px;
+  border-radius: ${borderRadius}px;
   font-weight: 600;
   background-color: ${({ theme, active }) => (active ? theme.bg1 : theme.bg3)};
   color: ${({ theme, active }) => (active ? theme.text1 : theme.text2)};

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -6,6 +6,7 @@ const StyledRangeInput = styled.input<{ size: number }>`
   width: 100%; /* Specific width is required for Firefox. */
   background: transparent; /* Otherwise white in Chrome */
   cursor: pointer;
+  padding: 16px 0;
 
   &:focus {
     outline: none;
@@ -109,7 +110,6 @@ export default function Slider({ value, onChange, min = 0, step = 1, max = 100, 
       size={size}
       type="range"
       value={value}
-      style={{ width: '90%', marginLeft: 15, marginRight: 15, padding: '15px 0' }}
       onChange={changeCallback}
       aria-labelledby="input slider"
       step={step}

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -1,4 +1,3 @@
-import { gql } from '@apollo/client'
 import { useContractKit } from '@celo-tools/use-contractkit'
 import { Fraction, Token } from '@ubeswap/sdk'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
@@ -10,7 +9,7 @@ import { ApprovalState } from 'hooks/useApproveCallback'
 import { CompoundBotSummary } from 'pages/Compound/useCompoundRegistry'
 import { useLPValue } from 'pages/Earn/useLPValue'
 import { MaxButton } from 'pages/Pool/styleds'
-import React, { useCallback, useContext, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { ArrowDown } from 'react-feather'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
@@ -42,7 +41,7 @@ const Wrapper = styled(AutoColumn)<{ showBackground: boolean }>`
   width: 100%;
   overflow: hidden;
   position: relative;
-  padding: 1rem;
+  padding: 16px;
   background: ${({ theme }) => theme.bg1};
   min-height: 110px;
   ${({ showBackground }) =>
@@ -64,62 +63,64 @@ const TopSection = styled.div`
   `};
 `
 
-const BottomSection = styled.div<{ showBackground: boolean }>`
-  padding: 12px 16px;
-  opacity: ${({ showBackground }) => (showBackground ? '1' : '0.4')};
-  border-radius: 0 0 ${borderRadius}px ${borderRadius}px;
+const RowColumn = styled(RowBetween)`
+  flex-direction: row;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 12px 0;
+  `};
+`
+
+const ZapOutContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 12px;
-  z-index: 1;
 `
 
 const PoolDetailsContainer = styled.div<{ $expanded: boolean }>`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 16px;
   max-height: ${({ $expanded }) => ($expanded ? '610px' : '0')};
-  transition: max-height 0.2s ${({ $expanded }) => ($expanded ? 'ease-in' : 'ease-out')};
+  margin-top: ${({ $expanded }) => ($expanded ? '12px' : '0')};
+  transition: all 0.2s ${({ $expanded }) => ($expanded ? 'ease-in' : 'ease-out')};
   overflow: hidden;
+  #zap-out-token-selector {
+    width: unset;
+    padding-top: 0;
+    > div {
+      border: none;
+    }
+  }
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    #zap-out-token-selector {
+      padding-top: 12px;
+    }
+  `};
 `
 
 const ManageMenu = styled.div<{ $expanded: boolean }>`
   display: flex;
   gap: 1rem;
-  max-height: ${({ $expanded }) => ($expanded ? '610px' : '0')};
-  transition: max-height 0.2s ${({ $expanded }) => ($expanded ? 'ease-in' : 'ease-out')};
+  margin-top: ${({ $expanded }) => ($expanded ? '12px' : '0')};
+  max-height: ${({ $expanded }) => ($expanded ? '40px' : '0')};
+  transition: all 0.2s ${({ $expanded }) => ($expanded ? 'ease-in' : 'ease-out')};
   overflow: hidden;
 `
 
 const ZapDetailsContainer = styled.div<{ $expanded: boolean }>`
-  padding: 12px 16px;
   max-height: ${({ $expanded }) => ($expanded ? '400px' : '0')};
-  transition: max-height 0.2s ${({ $expanded }) => ($expanded ? 'ease-in' : 'ease-out')};
+  transition: all 0.2s ${({ $expanded }) => ($expanded ? 'ease-in' : 'ease-out')};
   overflow: hidden;
-`
-
-const ZapOutTokenSelectorContainer = styled.div`
-  #zap-out-token-selector {
-  }
 `
 
 interface Props {
   compoundBotSummary: CompoundBotSummary
 }
 
-const pairDataGql = gql`
-  query getPairHourData($id: String!) {
-    pair(id: $id) {
-      pairHourData(first: 24, orderBy: hourStartUnix, orderDirection: desc) {
-        hourStartUnix
-        hourlyVolumeUSD
-      }
-    }
-  }
-`
-
 type ZapType = 'zapIn' | 'zapOut' | 'zapBetween'
+
+const zapOutPercentages = [25, 50, 75, 100]
 
 export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
   const { t } = useTranslation()
@@ -151,17 +152,25 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
   // })
 
   const [zapType, setZapType] = useState<ZapType | null>(null)
+  // TODO: show zap completed state rather than just collapsing the whole box
+  const [zapComplete, setZapComplete] = useState(false)
   const [showManageMenu, setShowManageMenu] = useState(false)
+  const [expanded, setExpanded] = useState(false)
 
   // TODO: these 2 are not needed anymore, can get them from redux
   const [zapAmount, setZapInAmount] = useState('')
   const [zapCurrency, setZapInCurrency] = useState<Token | undefined>()
 
-  const onZapSubmitted = (): void => {
-    setZapType(null)
+  const onZapComplete = () => {
+    setZapComplete(true)
   }
+
+  useEffect(() => {
+    setZapComplete(false)
+  }, [zapType, showManageMenu, expanded, zapAmount, zapCurrency])
+
   const { approval, approveCallback, onZap, showApproveFlow, currencies, approvalSubmitted } =
-    useZapFunctions(onZapSubmitted)
+    useZapFunctions(onZapComplete)
 
   const isStaking = compoundBotSummary.amountUserLP > 0
 
@@ -199,15 +208,19 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
   }
 
   const handleSetZapType = (type: ZapType) => {
-    setZapType(type)
-    if (type == 'zapOut') {
-      setZapOutPercentage('50')
-    }
-    onCurrencySelection(Field.INPUT, null)
-    onCurrencySelection(Field.OUTPUT, null)
-    onUserInput(Field.INPUT, '')
-    setZapInAmount('')
-    setZapInCurrency(undefined)
+    setExpanded(!!type)
+    // allow animation to finish
+    setTimeout(() => {
+      setZapType(type)
+      if (type == 'zapOut') {
+        setZapOutPercentage(50)
+      }
+      onCurrencySelection(Field.INPUT, null)
+      onCurrencySelection(Field.OUTPUT, null)
+      onUserInput(Field.INPUT, '')
+      setZapInAmount('')
+      setZapInCurrency(undefined)
+    }, 200)
   }
 
   const handleUserInput = (amount: string) => {
@@ -225,7 +238,7 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
     [handleUserInput]
   )
 
-  const [zapOutPercentage, setZapOutPercentage] = useDebouncedChangeHandler('50', zapOutPercentChangeCallback)
+  const [zapOutPercentage, setZapOutPercentage] = useDebouncedChangeHandler<number>(50, zapOutPercentChangeCallback)
 
   if (!token0 || !token1) {
     return (
@@ -254,55 +267,65 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
         </PoolInfo>
 
         {address && (
-          <ButtonPrimary onClick={handleToggleExpanded} padding="8px">
+          <ButtonPrimary onClick={handleToggleExpanded} inverse={!showManageMenu} padding="8px">
             {isStaking ? t('manage') : t('zapIn')}
           </ButtonPrimary>
         )}
       </TopSection>
 
-      {tvlCUSD && (
-        <RowBetween padding="8px 0">
-          <TYPE.black fontWeight={500}>
-            <span>Total Deposited</span>
-          </TYPE.black>
+      <RowBetween padding="8px 0">
+        <TYPE.black fontWeight={500}>
+          <span>Total Deposited</span>
+        </TYPE.black>
 
-          <RowFixed>
-            <TYPE.black style={{ textAlign: 'right' }} fontWeight={500}>
-              {Number(tvlCUSD.toFixed(2)).toLocaleString(undefined, {
-                style: 'currency',
-                currency: 'USD',
-                maximumFractionDigits: 0,
-              })}
-            </TYPE.black>
-            <QuestionHelper text={'Total value deposited in the farm bot by anyone, in US Dollars'} />
-          </RowFixed>
-        </RowBetween>
-      )}
+        <RowFixed>
+          {tvlCUSD ? (
+            <>
+              <TYPE.black style={{ textAlign: 'right' }} fontWeight={500}>
+                {Number(tvlCUSD.toFixed(2)).toLocaleString(undefined, {
+                  style: 'currency',
+                  currency: 'USD',
+                  maximumFractionDigits: 0,
+                })}
+              </TYPE.black>
+              <QuestionHelper text={'Total value deposited in the farm bot by anyone, in US Dollars'} />
+            </>
+          ) : (
+            <Loader centered size="24px" />
+          )}
+        </RowFixed>
+      </RowBetween>
 
-      {isStaking && userValueCUSD && (
+      {isStaking && (
         <RowBetween padding="8px 0">
           <TYPE.black fontWeight={500}>
             <span>Your stake</span>
           </TYPE.black>
 
           <RowFixed>
-            <TYPE.black style={{ textAlign: 'right' }} fontWeight={500}>
-              ${userValueCUSD.toFixed(2, { groupSeparator: ',' })}
-            </TYPE.black>
-            <QuestionHelper
-              text={`${userAmountTokenA?.toSignificant(6, { groupSeparator: ',' })} ${
-                userAmountTokenA?.token.symbol
-              }, ${userAmountTokenB?.toSignificant(6, { groupSeparator: ',' })} ${userAmountTokenB?.token.symbol}`}
-            />
+            {userValueCUSD ? (
+              <>
+                <TYPE.black style={{ textAlign: 'right' }} fontWeight={500}>
+                  ${userValueCUSD.toFixed(2, { groupSeparator: ',' })}
+                </TYPE.black>
+                <QuestionHelper
+                  text={`${userAmountTokenA?.toSignificant(6, { groupSeparator: ',' })} ${
+                    userAmountTokenA?.token.symbol
+                  }, ${userAmountTokenB?.toSignificant(6, { groupSeparator: ',' })} ${userAmountTokenB?.token.symbol}`}
+                />
+              </>
+            ) : (
+              <Loader centered size="24px" />
+            )}
           </RowFixed>
         </RowBetween>
       )}
 
       <ManageMenu $expanded={showManageMenu}>
-        <ButtonPrimary onClick={() => handleSetZapType('zapIn')} padding="8px" disabled={zapType === 'zapIn'}>
+        <ButtonPrimary onClick={() => handleSetZapType('zapIn')} padding="8px" inverse={zapType !== 'zapIn'}>
           {t('zapIn')}
         </ButtonPrimary>
-        <ButtonPrimary onClick={() => handleSetZapType('zapOut')} padding="8px" disabled={zapType === 'zapOut'}>
+        <ButtonPrimary onClick={() => handleSetZapType('zapOut')} padding="8px" inverse={zapType !== 'zapOut'}>
           {t('zapOut')}
         </ButtonPrimary>
       </ManageMenu>
@@ -312,7 +335,7 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
           <CurrencyInputPanel
             value={zapAmount}
             onUserInput={handleUserInput}
-            label={zapType === 'zapIn' ? t('zapInAmount') : t('zapOutAmount')}
+            label={t('zapInAmount')}
             showMaxButton={false}
             currency={zapCurrency}
             onCurrencySelect={handleCurrencySelect}
@@ -322,17 +345,17 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
         )}
 
         {zapType == 'zapOut' && (
-          <AutoColumn>
-            <RowBetween padding="12px">
-              <TYPE.black fontWeight={500}>
-                <span>{t('zapOutSelect')}</span>
-              </TYPE.black>
+          <ZapOutContainer>
+            <div>
+              <RowColumn padding="12px 0">
+                <TYPE.black fontWeight={500}>
+                  <span>{t('zapOutSelect')}</span>
+                </TYPE.black>
 
-              <ZapOutTokenSelectorContainer>
                 <CurrencyInputPanel
                   value={zapAmount}
                   onUserInput={handleUserInput}
-                  label={zapType === 'zapIn' ? t('zapInAmount') : t('zapOutAmount')}
+                  label={t('zapOutAmount')}
                   showMaxButton={false}
                   currency={zapCurrency}
                   onCurrencySelect={handleCurrencySelect}
@@ -340,31 +363,28 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
                   hideInput={true}
                   id="zap-out-token-selector"
                 />
-              </ZapOutTokenSelectorContainer>
-            </RowBetween>
+              </RowColumn>
+            </div>
             {zapCurrency && (
               <AutoColumn>
                 <LightCard>
                   <>
                     <Row style={{ alignItems: 'flex-end' }}>
-                      <Text fontSize={72} fontWeight={500}>
+                      <Text fontSize={48} fontWeight={500}>
                         {zapOutPercentage}%
                       </Text>
                     </Row>
                     <Slider value={zapOutPercentage} onChange={setZapOutPercentage} />
                     <RowBetween>
-                      <MaxButton onClick={() => setZapOutPercentage('25')} width="20%">
-                        25%
-                      </MaxButton>
-                      <MaxButton onClick={() => setZapOutPercentage('50')} width="20%">
-                        50%
-                      </MaxButton>
-                      <MaxButton onClick={() => setZapOutPercentage('75')} width="20%">
-                        75%
-                      </MaxButton>
-                      <MaxButton onClick={() => setZapOutPercentage('100')} width="20%">
-                        Max
-                      </MaxButton>
+                      {zapOutPercentages.map((zapOutPercentage) => (
+                        <MaxButton
+                          key={zapOutPercentage}
+                          onClick={() => setZapOutPercentage(zapOutPercentage)}
+                          width="25%"
+                        >
+                          {`${zapOutPercentage}%`}
+                        </MaxButton>
+                      ))}
                     </RowBetween>
                   </>
                 </LightCard>
@@ -393,10 +413,10 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
                 )}
               </AutoColumn>
             )}
-          </AutoColumn>
+          </ZapOutContainer>
         )}
 
-        <RowBetween gap="12px">
+        <RowBetween gap="16px">
           {showApproveFlow && (
             <ButtonConfirmed
               padding="8px"
@@ -426,13 +446,13 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
             </ButtonLight>
           )}
         </RowBetween>
-      </PoolDetailsContainer>
 
-      {!!zapType && !swapInputError && (
-        <ZapDetailsContainer $expanded={!!zapType && !swapInputError}>
-          <ZapDetails trade={trade} allowedSlippage={allowedSlippage} />
-        </ZapDetailsContainer>
-      )}
+        {!swapInputError && (
+          <ZapDetailsContainer $expanded={!!zapType && !swapInputError}>
+            <ZapDetails trade={trade} allowedSlippage={allowedSlippage} />
+          </ZapDetailsContainer>
+        )}
+      </PoolDetailsContainer>
     </Wrapper>
   )
 }

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -347,7 +347,7 @@ export const PoolCard: React.FC<Props> = ({ compoundBotSummary }: Props) => {
         {zapType == 'zapOut' && (
           <ZapOutContainer>
             <div>
-              <RowColumn padding="12px 0">
+              <RowColumn padding="0 0 12px 0">
                 <TYPE.black fontWeight={500}>
                   <span>{t('zapOutSelect')}</span>
                 </TYPE.black>

--- a/src/components/earn/styled.ts
+++ b/src/components/earn/styled.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { borderRadius } from 'theme'
 
 import uImage from '../../assets/images/big_unicorn.png'
 import noise from '../../assets/images/noise.webp'
@@ -18,7 +19,7 @@ export const TextBox = styled.div`
 
 export const DataCard = styled(AutoColumn)<{ disabled?: boolean }>`
   background-color: #171c60;
-  border-radius: 12px;
+  border-radius: ${borderRadius}px;
   width: 100%;
   position: relative;
   overflow: hidden;

--- a/src/components/earn/useZapFunctions.ts
+++ b/src/components/earn/useZapFunctions.ts
@@ -10,7 +10,7 @@ import { computeTradePriceBreakdown, warningSeverity } from 'utils/prices'
 // most of this logic taken from the Swap page
 // TODO: make use of expert mode/ displaying swap message/having a confirmation
 // modal for swap
-export const useZapFunctions = (onZapSubmitted) => {
+export const useZapFunctions = (onZapComplete?: () => void) => {
   const [{ showConfirm, tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{
     showConfirm: boolean
     tradeToConfirm: Trade | undefined
@@ -59,15 +59,12 @@ export const useZapFunctions = (onZapSubmitted) => {
     setSwapState({ attemptingTxn: true, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: undefined })
     swapCallback()
       .then((hash) => {
-        if (onZapSubmitted) {
-          onZapSubmitted()
+        if (onZapComplete) {
+          onZapComplete()
         }
         setSwapState({ attemptingTxn: false, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: hash })
       })
       .catch((error) => {
-        if (onZapSubmitted) {
-          onZapSubmitted()
-        }
         setSwapState({
           attemptingTxn: false,
           tradeToConfirm,

--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -15,6 +15,7 @@ import { TYPE } from '../../theme'
 
 const VoteCard = styled(DataCard)`
   overflow: hidden;
+  margin-bottom: 16px;
 `
 
 const PageWrapper = styled.div`
@@ -96,11 +97,11 @@ export default function Earn() {
             <CardSection>
               <AutoColumn gap="md">
                 <RowBetween>
-                  <TYPE.white fontWeight={600}>{t('ZapInEdu')}</TYPE.white>
+                  <TYPE.white fontWeight={600}>{t('zapInEdu')}</TYPE.white>
                 </RowBetween>
                 <RowBetween>
                   <TYPE.white fontSize={14}>
-                    {t('ZapInEduDesc')}
+                    {t('zapInEduDesc')}
                     <a href="https://docs.revo.market/">{t('here')}</a>
                   </TYPE.white>
                 </RowBetween>

--- a/src/pages/Pool/styleds.tsx
+++ b/src/pages/Pool/styleds.tsx
@@ -1,5 +1,6 @@
 import { Text } from 'rebass'
 import styled from 'styled-components'
+import { borderRadius } from 'theme'
 
 export const Wrapper = styled.div`
   position: relative;
@@ -15,8 +16,8 @@ export const ClickableText = styled(Text)`
 export const MaxButton = styled.button<{ width: string }>`
   padding: 0.5rem 1rem;
   background-color: ${({ theme }) => theme.primary3};
-  border: 1px solid ${({ theme }) => theme.primary3};
-  border-radius: 8px;
+  border: 2px solid ${({ theme }) => theme.primary3};
+  border-radius: ${borderRadius}px;
   font-size: 1rem;
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 0.25rem 0.5rem;
@@ -25,12 +26,12 @@ export const MaxButton = styled.button<{ width: string }>`
   cursor: pointer;
   margin: 0.25rem;
   overflow: hidden;
-  color: ${({ theme }) => theme.primary1};
+  color: ${({ theme }) => theme.bg2};
   :hover {
-    border: 1px solid ${({ theme }) => theme.primary1};
+    border: 2px solid ${({ theme }) => theme.primary2};
   }
   :focus {
-    border: 1px solid ${({ theme }) => theme.primary1};
+    border: 2px solid ${({ theme }) => theme.primary2};
     outline: none;
   }
 `


### PR DESCRIPTION
- improve spaces/border radius consistency
- make the bottom states more intuitive (i think having zap in or zap out disabled in the expanded manage view was not intuitive, as you couldn't switch back and forth between the views without collapsing the whole thing first)
- improve the dropdown animation smoothness (still not perfect but good enough)
- include loading state for TVL and staked value so that the UI does not jump around

<img width="719" alt="Screenshot 2022-03-12 at 08 26 24" src="https://user-images.githubusercontent.com/20150449/158008480-35fd01cd-4325-49cb-9529-efaecbddf128.png">


<img width="702" alt="Screenshot 2022-03-12 at 08 29 09" src="https://user-images.githubusercontent.com/20150449/158008551-eb8c3c23-eebb-428e-a08e-4f510328fda1.png">

