### PR TITLE
chore: add PACT-CELO to 'zap' tab

### DIFF
--- a/src/pages/Zap/index.tsx
+++ b/src/pages/Zap/index.tsx
@@ -43,7 +43,10 @@ const Header: React.FC = ({ children }) => {
   )
 }
 
-export const farmBotAddresses = ['0xCB34fbfC3b9a73bc04D2eb43B62532c7918d9E81']
+export const farmBotAddresses = [
+  '0xCB34fbfC3b9a73bc04D2eb43B62532c7918d9E81', // mcUSD-mcEUR
+  '0xec17fb85529a6a48cb6ed7e3c1d1a7cc57d742c1', // PACT-CELO
+]
 
 export const RFP_TOKEN_LIST = {
   name: 'Revo',


### PR DESCRIPTION
To add it to the "farm" tab we'll need to deploy a MoolaStakingRewards contract first and configure it. We can do that next.

Tests run:
- manually zapped in and out of the PACT-CELO farm bot

<img width="692" alt="Screen Shot 2022-04-26 at 8 33 50 PM" src="https://user-images.githubusercontent.com/7979215/165434637-ecf95c65-dc4b-42f4-9c9f-b5a37b116541.png">
 