### PR TITLE
chore(moola-incident): rm warning banner

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -94,12 +94,6 @@ export default function App() {
         <HeaderWrapper>
           <Header />
         </HeaderWrapper>
-        <ConstructionBanner>
-          <p>
-            Zaps may not work normally due to an ongoing incident with Moola Market. Follow along on
-            <a href="https://discord.com/invite/TBHYqgBnRj"> Discord</a>.
-          </p>
-        </ConstructionBanner>
         <BodyWrapper>
           <Popups />
           <Polling />


### PR DESCRIPTION
I tested swaps in both directions for both farms, and they work. 

This reverts commit 1f18be3ab463e8209c36faea80578cbd5b4f779e.